### PR TITLE
Fix href on image for 'about me'

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -51,7 +51,7 @@
 				<div class="row">
 					<section class="col-6 col-12-narrower">
 						<div class="box post">
-							<a href="#" class="image left"><img src="images/homepage-01-about-me.jpg" 
+							<a href="/about" class="image left"><img src="images/homepage-01-about-me.jpg" 
 								alt="Studio headshot of Dylan Beattie in front of a yellow background."
 								title="Dylan Beattie at KCDC 2019. Photograph by Tiffany Buckley / https://tiffanybuckley.com/" /></a>
 							<div class="inner">


### PR DESCRIPTION
Noticed the image next to your "about me" section on your index page was missing the link to the page. 